### PR TITLE
Feature/page-not-found

### DIFF
--- a/src/app/[lang]/[...not-found]/page.tsx
+++ b/src/app/[lang]/[...not-found]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function NotFoundDummy() {
+  notFound();
+}

--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function notFound() {
+  return (
+    <div className={"py-5"}>
+      <h2 className={"text-2xl font-bold text-center mb-5"}>404 - Page not found</h2>
+      <p className={"text-lg"}>Sorry, we couldn't find this page. These are some reasons why you see this:</p>
+      <ul className={"list-disc text-lg my-5 px-3 lg:px-0"}>
+        <li>You may have mistyped the address.</li>
+        <li>The page may have moved.</li>
+        <li>The page may have never existed.</li>
+      </ul>
+      <Link className={"underline"} href={"/"}>
+        &#8592; Return home
+      </Link>
+    </div>
+  );
+}

--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -4,7 +4,7 @@ export default function notFound() {
   return (
     <div className={"py-5"}>
       <h2 className={"text-2xl font-bold text-center mb-5"}>404 - Page not found</h2>
-      <p className={"text-lg"}>Sorry, we couldn't find this page. These are some reasons why you see this:</p>
+      <p className={"text-lg"}>Sorry, we couldn&apos;t find this page. These are some reasons why you see this:</p>
       <ul className={"list-disc text-lg my-5 px-3 lg:px-0"}>
         <li>You may have mistyped the address.</li>
         <li>The page may have moved.</li>


### PR DESCRIPTION
NOTE: This implementation makes use of the workaround described in [this discussion](https://github.com/vercel/next.js/discussions/50034). This is intended to be a temporary solution.

- Added dynamic catch-all route that calls notFound function.
- Added root not-found page.